### PR TITLE
Add feature flag to disable post validation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,29 @@ AC_SEARCH_LIBS([log], [m], [], [
   AC_MSG_ERROR([unable to find the log() function])
 ])
 
+# Feature flags
+###############
+
+# Select whether to validate benchmark computation after its execution.
+# Default is to perform validation.
+AC_ARG_ENABLE([post-validation],
+  [AS_HELP_STRING([--disable-post-validation], [skip post validation])],
+  [case "${enableval}" in
+     yes | no ) enable_post_validation="${enableval}" ;;
+     *) AC_MSG_ERROR([bad value ${enableval} for --disable-post-validation]) ;;
+   esac],
+  [enable_post_validation=yes]
+)
+AM_CONDITIONAL([ENABLE_POST_VALIDATION], [test "x${enable_post_validation}" = "xyes"])
+AS_IF([test "x${enable_post_validation}" = "xyes"],
+  [
+    AC_DEFINE([ENABLE_POST_VALIDATION], [1], [Define to 1 to perform a validation of the benchmark computation])
+  ],
+  [
+    AC_MSG_NOTICE([post validation disabled])
+  ]
+)
+
 # Output
 ########
 

--- a/src/progress/ones/npb/ep.c
+++ b/src/progress/ones/npb/ep.c
@@ -211,6 +211,7 @@ int main(int argc, char **argv)
 	fprintf(stdout, "Time (s): avg:       %11.6f min:  %11.6f max: %11.6f\n",
 		1.0E-09 * sumtime/times, 1.0E-09 * mintime, 1.0E-09 * maxtime);
 
+#ifdef ENABLE_POST_VALIDATION
 	/* validate the benchmark: minimum about of bits should be different.
 	 * Note that NAS does not give us a validation value for all inputs */
 	err = 0;
@@ -254,4 +255,8 @@ int main(int argc, char **argv)
 	else
 		fprintf(stdout, "VALIDATION PASSED!!!!\n");
 	return err;
+#else
+	fprintf(stdout, "VALIDATION disabled\n");
+	return 0;
+#endif
 }

--- a/src/progress/ones/stream/add.c
+++ b/src/progress/ones/stream/add.c
@@ -123,6 +123,7 @@ int main(int argc, char **argv)
 		(3.0E-06 * memory_size)/ (1.0E-09 * sumtime/times),
 		(3.0E-06 * memory_size)/ (1.0E-09 * mintime));
 
+#ifdef ENABLE_POST_VALIDATION
 	/* validate the benchmark: minimum about of bits should be different. */
 	err = 0;
 	for(size_t i = 0; i < array_size && err == 0; i++)
@@ -133,4 +134,8 @@ int main(int argc, char **argv)
 	else
 		fprintf(stdout, "VALIDATION PASSED!!!!\n");
 	return err;
+#else
+	fprintf(stdout, "VALIDATION disabled\n");
+	return 0;
+#endif
 }

--- a/src/progress/ones/stream/copy.c
+++ b/src/progress/ones/stream/copy.c
@@ -121,6 +121,7 @@ int main(int argc, char **argv)
 		(2.0E-06 * memory_size)/ (1.0E-09 * sumtime/times),
 		(2.0E-06 * memory_size)/ (1.0E-09 * mintime));
 
+#ifdef ENABLE_POST_VALIDATION
 	/* validate the benchmark: for a copy, the minimum about of bits should
 	 * be different.
 	 */
@@ -133,4 +134,8 @@ int main(int argc, char **argv)
 	else
 		fprintf(stdout, "VALIDATION PASSED!!!!\n");
 	return err;
+#else
+	fprintf(stdout, "VALIDATION disabled\n");
+	return 0;
+#endif
 }

--- a/src/progress/ones/stream/full.c
+++ b/src/progress/ones/stream/full.c
@@ -164,6 +164,7 @@ int main(int argc, char **argv)
 		(bytes[i] * 1.0E-06 * memory_size)/ (1.0E-09 * mintime[i]));
 	}
 
+#ifdef ENABLE_POST_VALIDATION
 	/* validate the benchmark: minimum about of bits should be different. */
 	err = 0;
 	double ai = 1.0, bi = 2.0, ci = 0.0;
@@ -184,4 +185,8 @@ int main(int argc, char **argv)
 	else
 		fprintf(stdout, "VALIDATION PASSED!!!!\n");
 	return err;
+#else
+	fprintf(stdout, "VALIDATION disabled\n");
+	return 0;
+#endif
 }

--- a/src/progress/ones/stream/scale.c
+++ b/src/progress/ones/stream/scale.c
@@ -122,6 +122,7 @@ int main(int argc, char **argv)
 		(2.0E-06 * memory_size)/ (1.0E-09 * sumtime/times),
 		(2.0E-06 * memory_size)/ (1.0E-09 * mintime));
 
+#ifdef ENABLE_POST_VALIDATION
 	/* validate the benchmark: minimum about of bits should be different. */
 	err = 0;
 	for(size_t i = 0; i < array_size && err == 0; i++)
@@ -132,4 +133,8 @@ int main(int argc, char **argv)
 	else
 		fprintf(stdout, "VALIDATION PASSED!!!!\n");
 	return err;
+#else
+	fprintf(stdout, "VALIDATION disabled\n");
+	return 0;
+#endif
 }

--- a/src/progress/ones/stream/triad.c
+++ b/src/progress/ones/stream/triad.c
@@ -124,6 +124,7 @@ int main(int argc, char **argv)
 		(3.0E-06 * memory_size)/ (1.0E-09 * sumtime/times),
 		(3.0E-06 * memory_size)/ (1.0E-09 * mintime));
 
+#ifdef ENABLE_POST_VALIDATION
 	/* validate the benchmark: minimum about of bits should be different. */
 	err = 0;
 	for(size_t i = 0; i < array_size && err == 0; i++)
@@ -134,4 +135,8 @@ int main(int argc, char **argv)
 	else
 		fprintf(stdout, "VALIDATION PASSED!!!!\n");
 	return err;
+#else
+	fprintf(stdout, "VALIDATION disabled\n");
+	return 0;
+#endif
 }


### PR DESCRIPTION
STREAM and NPB benchmarks perform a validation after the main computation.
This validation introduces a second phase that is not representative of the benchmark behavior.
For some experiments, this is undesirable.

This commit provides the `--disable-post-validation` feature flag to remove this validation phase.