### PR TITLE
[feature] CI: activate nix build on v0.7.x

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,0 +1,20 @@
+name: builds
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  VERBOSE: 1
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v13
+        with:
+          nix_path: nixpkgs=channel:nixos-20.09
+      - run: nix-build -A nrmb

--- a/nix/nrmb.nix
+++ b/nix/nrmb.nix
@@ -1,6 +1,6 @@
-{ stdenv, autoreconfHook, pkgconfig, libnrm }:
+{ stdenv, autoreconfHook, pkgconfig, libnrm, zeromq }:
 stdenv.mkDerivation {
   src = ../.;
   name = "nrm-benchmarks";
-  nativeBuildInputs = [ autoreconfHook pkgconfig libnrm ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig libnrm zeromq];
 }


### PR DESCRIPTION
The nix build is the only one on this branch that has some chance of building easily based on the tagged release on libnrm.