### PR TITLE
[fix] include the right directory for oot builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = autogen.sh README.markdown
 
-AM_CPPFLAGS = -Isrc $(OPENMP_CFLAGS) $(LIBNRM_CFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir)/src $(OPENMP_CFLAGS) $(LIBNRM_CFLAGS)
 AM_LDFLAGS = $(OPENMP_CFLAGS) $(LIBNRM_LIBS)
 
 include_HEADERS=src/nrm-benchmarks.h


### PR DESCRIPTION
Out-of-tree builds have top_builddir != top_srcdir, fix includes to reflect that.

Fixes #3 