### PR TITLE
[feature] upgrade all benchmark to libnrm current

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,8 @@
 ACLOCAL_AMFLAGS = -I m4
 EXTRA_DIST = autogen.sh README.markdown
 
-AM_CPPFLAGS = -I$(top_srcdir)/src $(OPENMP_CFLAGS) $(LIBNRM_CFLAGS) #$(BLAS_CFLAGS)
-AM_LDFLAGS = $(OPENMP_CFLAGS) $(LIBNRM_LIBS) #$(BLAS_LIBS)
+AM_CPPFLAGS = -I$(top_srcdir)/src $(OPENMP_CFLAGS) $(LIBNRM_CFLAGS) $(BLAS_CFLAGS)
+AM_LDFLAGS = $(OPENMP_CFLAGS) $(LIBNRM_LIBS) $(BLAS_LIBS)
 
 include_HEADERS=src/nrm-benchmarks.h
 UTILS_SOURCES = src/utils.c
@@ -22,41 +22,35 @@ ones_stream_triad_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/triad.c
 ones_stream_full_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/full.c
 noprogress_stream_full_SOURCES = $(UTILS_SOURCES) src/noprogress/stream/full.c
 
-#ones_solvers_cg_SOURCES = $(UTILS_SOURCES) \
-#			  src/progress/ones/iterative_solvers/common.h \
-#			  src/progress/ones/iterative_solvers/cg.c
-#ones_solvers_bicgstab_SOURCES = $(UTILS_SOURCES) \
-#			  src/progress/ones/iterative_solvers/common.h \
-#			  src/progress/ones/iterative_solvers/bicgstab.c
-#
-#NPB_UTILS_SOURCES = src/progress/ones/npb/randdp.c
-#ones_npb_ep_SOURCES = $(UTILS_SOURCES) $(NPB_UTILS_SOURCES) src/progress/ones/npb/ep.c
-#
-#phases_stream_full_SOURCES = $(UTILS_SOURCES) src/progress/phases/stream/full.c
-#
-#phases_solvers_cg_SOURCES = $(UTILS_SOURCES) \
-#			  src/progress/phases/iterative_solvers/common.h \
-#			  src/progress/phases/iterative_solvers/cg.c
-#
-#phases_solvers_bicgstab_SOURCES = $(UTILS_SOURCES) \
-#			  src/progress/phases/iterative_solvers/common.h \
-#			  src/progress/phases/iterative_solvers/bicgstab.c
-#
-#bin_PROGRAMS = ones-solvers-cg \
-#	       ones-solvers-bicgstab \
-#	       ones-stream-copy \
-#	       ones-stream-scale \
-#	       ones-stream-add \
-#	       ones-stream-triad \
-#	       ones-stream-full \
-#	       ones-npb-ep \
-#	       phases-stream-full \
-#	       phases-solvers-cg \
-#	       phases-solvers-bicgstab
-#
-bin_PROGRAMS = ones-stream-full \
+ones_solvers_cg_SOURCES = $(UTILS_SOURCES) \
+			  src/progress/ones/iterative_solvers/common.h \
+			  src/progress/ones/iterative_solvers/cg.c
+ones_solvers_bicgstab_SOURCES = $(UTILS_SOURCES) \
+			  src/progress/ones/iterative_solvers/common.h \
+			  src/progress/ones/iterative_solvers/bicgstab.c
+
+NPB_UTILS_SOURCES = src/progress/ones/npb/randdp.c
+ones_npb_ep_SOURCES = $(UTILS_SOURCES) $(NPB_UTILS_SOURCES) src/progress/ones/npb/ep.c
+
+phases_stream_full_SOURCES = $(UTILS_SOURCES) src/progress/phases/stream/full.c
+
+phases_solvers_cg_SOURCES = $(UTILS_SOURCES) \
+			  src/progress/phases/iterative_solvers/common.h \
+			  src/progress/phases/iterative_solvers/cg.c
+
+phases_solvers_bicgstab_SOURCES = $(UTILS_SOURCES) \
+			  src/progress/phases/iterative_solvers/common.h \
+			  src/progress/phases/iterative_solvers/bicgstab.c
+
+bin_PROGRAMS = ones-solvers-cg \
+	       ones-solvers-bicgstab \
 	       ones-stream-copy \
 	       ones-stream-scale \
 	       ones-stream-add \
 	       ones-stream-triad \
+	       ones-stream-full \
+	       ones-npb-ep \
+	       phases-stream-full \
+	       phases-solvers-cg \
+	       phases-solvers-bicgstab \
 	       noprogress-stream-full

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,10 +15,10 @@ UTILS_SOURCES = src/utils.c
 # BENCHMARKS
 ###############################################################################
 
-#ones_stream_copy_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/copy.c
-#ones_stream_scale_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/scale.c
-#ones_stream_add_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/add.c
-#ones_stream_triad_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/triad.c
+ones_stream_copy_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/copy.c
+ones_stream_scale_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/scale.c
+ones_stream_add_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/add.c
+ones_stream_triad_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/triad.c
 ones_stream_full_SOURCES = $(UTILS_SOURCES) src/progress/ones/stream/full.c
 noprogress_stream_full_SOURCES = $(UTILS_SOURCES) src/noprogress/stream/full.c
 
@@ -55,4 +55,8 @@ noprogress_stream_full_SOURCES = $(UTILS_SOURCES) src/noprogress/stream/full.c
 #	       phases-solvers-bicgstab
 #
 bin_PROGRAMS = ones-stream-full \
+	       ones-stream-copy \
+	       ones-stream-scale \
+	       ones-stream-add \
+	       ones-stream-triad \
 	       noprogress-stream-full

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ LT_INIT
 AC_OPENMP
 
 PKG_CHECK_MODULES([LIBNRM], [libnrm])
-#PKG_CHECK_MODULES([BLAS], [blas])
+PKG_CHECK_MODULES([BLAS], [blas])
 
 AC_SEARCH_LIBS([log], [m], [], [
   AC_MSG_ERROR([unable to find the log() function])

--- a/nix/libnrm.nix
+++ b/nix/libnrm.nix
@@ -24,13 +24,15 @@ stdenv.mkDerivation {
   buildInputs = [
     bats
     check
-    czmq
     hwloc
     jansson
     mpich
     openmp
     papi
     protobufc
+  ];
+  propagatedBuildInputs = [
+    czmq
     zeromq
   ];
 }

--- a/nix/nrmb.nix
+++ b/nix/nrmb.nix
@@ -2,6 +2,6 @@
 stdenv.mkDerivation {
   src = ../.;
   name = "nrm-benchmarks";
-  nativeBuildInputs = [ autoreconfHook pkgconfig libnrm czmq zeromq blas];
-  buildInputs = [ libnrm ];
+  nativeBuildInputs = [ autoreconfHook pkgconfig ];
+  buildInputs = [ libnrm blas czmq zeromq ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@
 { pkgs ? import ./. { } }:
 with pkgs;
 mkShell {
-  inputsFrom = [ nrmb ] ++ libnrm.buildInputs;
+  inputsFrom = [ nrmb ];
   nativeBuildInputs = [ autoreconfHook pkgconfig ];
   buildInputs = [
     # deps for debug

--- a/src/progress/ones/iterative_solvers/bicgstab.c
+++ b/src/progress/ones/iterative_solvers/bicgstab.c
@@ -27,8 +27,6 @@
 static double *A, *b, *x;
 int LOG;
 
-static struct nrm_context *context;
-
 void bicgstab(double *A, double *b, double *x, int n, int maxiter)
 {
     int total_iterations = 0;
@@ -41,14 +39,14 @@ void bicgstab(double *A, double *b, double *x, int n, int maxiter)
     double *t = (double *)malloc(n * sizeof(double));
     double alpha, omega, rho, rho_prime = 1.0;
 
-    nrm_send_progress(context, 1);
+    nrmb_send_progress(1.0);
 
     // Initial residual
     cblas_dcopy(n, b, 1, r, 1);
     cblas_dgemv(CblasRowMajor, CblasNoTrans, n, n, -1.0, A, n, x, 1, 1.0, r, 1);
     cblas_dcopy(n, r, 1, r_hat, 1);
 
-    nrm_send_progress(context, 1);
+    nrmb_send_progress(1.0);
 
     for (int iter = 0; iter < n && iter < maxiter; ++iter)
     {
@@ -106,7 +104,7 @@ void bicgstab(double *A, double *b, double *x, int n, int maxiter)
             printf("Step: %d Error: %.11lf\n", iter, fabs(rho_prime));
         }
 		total_iterations = iter;
-	nrm_send_progress(context, 1);
+	nrmb_send_progress(1.0);
     }
 
     free(r);
@@ -132,9 +130,8 @@ int main(int argc, char *argv[])
     b = (double *)malloc(n * sizeof(double));
     x = (double *)malloc(n * sizeof(double));
 
-    context = nrm_ctxt_create();
-    nrm_init(context, argv[0], 0, 0);
-    nrm_send_progress(context, 1);
+    nrmb_init(argv[0]);
+    nrmb_send_progress(1.0);
 
     if (strcmp(conditionning, "good") == 0)
     {
@@ -157,8 +154,7 @@ int main(int argc, char *argv[])
     bicgstab(A, b, x, n, maxiter);
     gettimeofday(&finish, NULL);
 
-    nrm_fini(context);
-    nrm_ctxt_delete(context);
+    nrmb_finalize();
 
     time = (finish.tv_sec - start.tv_sec);
     time += (finish.tv_usec - start.tv_usec)/1e6;

--- a/src/progress/ones/iterative_solvers/cg.c
+++ b/src/progress/ones/iterative_solvers/cg.c
@@ -27,7 +27,6 @@
 static double *A, *b, *x;
 int LOG;
 
-static struct nrm_context *context;
 
 void conjugate_gradient(double *A, double *b, double *x, int n, int maxiter)
 {
@@ -38,7 +37,7 @@ void conjugate_gradient(double *A, double *b, double *x, int n, int maxiter)
     p = (double *)malloc(n * sizeof(double));
     Ap = (double *)malloc(n * sizeof(double));
 
-    nrm_send_progress(context, 1);
+    nrmb_send_progress(1.0);
 
     cblas_dcopy(n, b, 1, r, 1);
     cblas_dgemv(CblasRowMajor, CblasNoTrans, n, n, -1.0, A, n, x, 1, 1.0, r, 1);
@@ -48,7 +47,7 @@ void conjugate_gradient(double *A, double *b, double *x, int n, int maxiter)
     double old_residual, residual;
     old_residual = cblas_ddot(n, r, 1, r, 1);
 
-    nrm_send_progress(context, 1);
+    nrmb_send_progress(1.0);
 
     for (int iter = 0; iter <= n && iter <= maxiter; iter++)
     {
@@ -77,7 +76,7 @@ void conjugate_gradient(double *A, double *b, double *x, int n, int maxiter)
             printf("Step: %d Error: %.11lf\n", iter, sqrt(old_residual));
         }
 		total_iterations = iter;
-	nrm_send_progress(context, 1);
+	nrmb_send_progress(1.0);
     }
 
     free(r);
@@ -100,9 +99,8 @@ int main(int argc, char *argv[])
     b = (double *)malloc(n * sizeof(double));
     x = (double *)malloc(n * sizeof(double));
 
-    context = nrm_ctxt_create();
-    nrm_init(context, argv[0], 0, 0);
-    nrm_send_progress(context, 1);
+    nrmb_init(argv[0]);
+    nrmb_send_progress(1.0);
 
     if (strcmp(conditionning, "good") == 0)
     {
@@ -125,8 +123,7 @@ int main(int argc, char *argv[])
     conjugate_gradient(A, b, x, n, maxiter);
 	gettimeofday(&finish, NULL);
 
-    nrm_fini(context);
-    nrm_ctxt_delete(context);
+    nrmb_finalize();
 
     time = (finish.tv_sec - start.tv_sec);
     time += (finish.tv_usec - start.tv_usec)/1e6;

--- a/src/progress/ones/stream/add.c
+++ b/src/progress/ones/stream/add.c
@@ -15,9 +15,6 @@
 #include <nrm.h>
 
 static double *a, *b, *c;
-static struct nrm_context *context;
-
-static struct nrm_scope *region_scope, **thread_scope;
 
 int main(int argc, char **argv)
 {
@@ -30,7 +27,7 @@ int main(int argc, char **argv)
 
 	/* needed for performance measurement */
 	int64_t sumtime = 0, mintime = INT64_MAX, maxtime = 0;
-	nrmb_time_t start, end;
+	nrm_time_t start, end;
 	size_t memory_size;
 	int num_threads;
 
@@ -74,8 +71,7 @@ int main(int argc, char **argv)
 	}
 
 	/* NRM Context init */
-	context = nrm_ctxt_create();
-	nrm_init(context, argv[0], 0, 0);
+	nrmb_init(argv[0]);
 
 	/* one run of the benchmark for free, warms up the memory */
 #pragma omp parallel for
@@ -85,54 +81,32 @@ int main(int argc, char **argv)
 	/* this version of the benchmarks reports one progress each time it goes
 	 * through the entire array.
 	 */
-    /* Create scopes */
-    region_scope = nrm_scope_create();
-    thread_scope = malloc(num_threads*sizeof(nrm_scope_t*));
-    for (int i = 0; i < num_threads; i++)
-    {
-        thread_scope[i] = nrm_scope_create();
-    }
 
-    /* Get master process scope */
-    nrm_scope_threadshared(region_scope);
-    nrm_send_progress(context, 1, region_scope);
+	nrmb_send_progress(1.0);
 
 	for(long int iter = 0; iter < times; iter++)
 	{
 		int64_t time;
-		nrmb_gettime(&start);
+		nrm_time_gettime(&start);
 
 		/* the actual benchmark */
 #pragma omp parallel for
 		for(size_t i = 0; i < array_size; i++)
-        {	
-            c[i] = a[i] + b[i];
-            /* Get scopes */
-            nrm_scope_threadshared(region_scope);
-            nrm_scope_threadprivate(thread_scope[omp_get_thread_num()]);
-            nrm_send_progress(context, 1, thread_scope[omp_get_thread_num()]);
-        }
+		{
+			c[i] = a[i] + b[i];
+		}
 
-		nrmb_gettime(&end);
-        nrm_send_progress(context, 1, region_scope);
-
-		time = nrmb_timediff(&start, &end);
+		nrmb_send_progress(1.0);
+		nrm_time_gettime(&end);
+		time = nrm_time_diff(&start, &end);
 		sumtime += time;
 		mintime = NRMB_MIN(time, mintime);
 		maxtime = NRMB_MAX(time, maxtime);
 	}
 
-	nrm_fini(context);
-	nrm_ctxt_delete(context);
+	nrmb_finalize();
 
-    /* Delete scopes */
-    nrm_scope_delete(region_scope);
-    for (int i = 0; i < num_threads; i++)
-    {
-        nrm_scope_delete(thread_scope[i]);
-    }
-	
-    /* compute stats */
+	/* compute stats */
 
 	/* report the configuration and timings */
 	fprintf(stdout, "NRM Benchmarks:      %s\n", argv[0]);

--- a/src/progress/ones/stream/copy.c
+++ b/src/progress/ones/stream/copy.c
@@ -17,9 +17,6 @@
 #include <stddef.h>
 
 static double *a, *b;
-static struct nrm_context *context;
-
-static struct nrm_scope *region_scope, **thread_scope;
 
 int main(int argc, char **argv)
 {
@@ -32,7 +29,7 @@ int main(int argc, char **argv)
 
     /* needed for performance measurement */
     int64_t sumtime = 0, mintime = INT64_MAX, maxtime = 0;
-    nrmb_time_t start, end;
+    nrm_time_t start, end;
     size_t memory_size;
     int num_threads;
 
@@ -74,8 +71,7 @@ int main(int argc, char **argv)
     }
 
     /* NRM Context init */
-    context = nrm_ctxt_create();
-    nrm_init(context, argv[0], 0, 0);
+    nrmb_init(argv[0]);
 
     /* one run of the benchmark for free, warms up the memory */
 #pragma omp parallel for
@@ -85,53 +81,30 @@ int main(int argc, char **argv)
     /* this version of the benchmarks reports one progress each time it goes
      * through the entire array.
      */
-    /* Create scopes */
-    region_scope = nrm_scope_create();
-    thread_scope = malloc(num_threads*sizeof(nrm_scope_t*));
-    for (int i = 0; i < num_threads; i++)
-    {
-        thread_scope[i] = nrm_scope_create();
-    }
-
-    /* Get master process scope */
-    nrm_scope_threadshared(region_scope);
-    nrm_send_progress(context, 1, region_scope);
+    nrmb_send_progress(1.0);
 
     for(long int iter = 0; iter < times; iter++)
     {
         int64_t time;
-        nrmb_gettime(&start);
+        nrm_time_gettime(&start);
 
         /* the actual benchmark */
 #pragma omp parallel for
         for(size_t i = 0; i < array_size; i++)
         {
             b[i] = a[i];
-            /* Get scopes */
-            nrm_scope_threadshared(region_scope);
-            nrm_scope_threadprivate(thread_scope[omp_get_thread_num()]);
-            nrm_send_progress(context, 1, thread_scope[omp_get_thread_num()]);
         }
         
-        nrmb_gettime(&end);
-        nrm_send_progress(context, 1, region_scope);
+	nrmb_send_progress(1.0);
+        nrm_time_gettime(&end);
 
-        time = nrmb_timediff(&start, &end);
+        time = nrm_time_diff(&start, &end);
         sumtime += time;
         mintime = NRMB_MIN(time, mintime);
         maxtime = NRMB_MAX(time, maxtime);
     }
 
-    nrm_fini(context);
-    nrm_ctxt_delete(context);
-
-    /* Delete scopes */
-    nrm_scope_delete(region_scope);
-    for (int i = 0; i < num_threads; i++)
-    {
-        nrm_scope_delete(thread_scope[i]);
-    }
-
+    nrmb_finalize();
     /* compute stats */
 
     /* report the configuration and timings */

--- a/src/progress/ones/stream/full.c
+++ b/src/progress/ones/stream/full.c
@@ -15,9 +15,6 @@
 #include <nrm.h>
 
 static double *a, *b, *c;
-static struct nrm_context *context;
-
-static struct nrm_scope *region_scope, **thread_scope;
 
 int main(int argc, char **argv)
 {

--- a/src/progress/ones/stream/triad.c
+++ b/src/progress/ones/stream/triad.c
@@ -15,9 +15,6 @@
 #include <nrm.h>
 
 static double *a, *b, *c;
-static struct nrm_context *context;
-
-static struct nrm_scope *region_scope, **thread_scope;
 
 int main(int argc, char **argv)
 {
@@ -31,7 +28,7 @@ int main(int argc, char **argv)
 
 	/* needed for performance measurement */
 	int64_t sumtime = 0, mintime = INT64_MAX, maxtime = 0;
-	nrmb_time_t start, end;
+	nrm_time_t start, end;
 	size_t memory_size;
 	int num_threads;
 
@@ -75,8 +72,7 @@ int main(int argc, char **argv)
 	}
 
 	/* NRM Context init */
-	context = nrm_ctxt_create();
-	nrm_init(context, argv[0], 0, 0);
+	nrmb_init(argv[0]);
 
 	/* one run of the benchmark for free, warms up the memory */
 #pragma omp parallel for
@@ -86,53 +82,30 @@ int main(int argc, char **argv)
 	/* this version of the benchmarks reports one progress each time it goes
 	 * through the entire array.
 	 */
-    /* Create scopes */
-    region_scope = nrm_scope_create();
-    thread_scope = malloc(num_threads*sizeof(nrm_scope_t*));
-    for (int i = 0; i < num_threads; i++)
-    {
-        thread_scope[i] = nrm_scope_create();
-    }
-
-    /* Get master process scope */
-    nrm_scope_threadshared(region_scope);
-    nrm_send_progress(context, 1, region_scope);
+	nrmb_send_progress(1.0);
 
 	for(long int iter = 0; iter < times; iter++)
 	{
 		int64_t time;
-		nrmb_gettime(&start);
+		nrm_time_gettime(&start);
 
 		/* the actual benchmark */
 #pragma omp parallel for
 		for(size_t i = 0; i < array_size; i++)
         {
 			c[i] = a[i] + scalar*b[i];
-            /* Get scopes */
-            nrm_scope_threadshared(region_scope);
-            nrm_scope_threadprivate(thread_scope[omp_get_thread_num()]);
-            nrm_send_progress(context, 1, thread_scope[omp_get_thread_num()]);
         }
 
-		nrmb_gettime(&end);
-        nrm_send_progress(context, 1, region_scope);
+	nrm_time_gettime(&end);
+	nrmb_send_progress(1.0);
 
-		time = nrmb_timediff(&start, &end);
+		time = nrm_time_diff(&start, &end);
 		sumtime += time;
 		mintime = NRMB_MIN(time, mintime);
 		maxtime = NRMB_MAX(time, maxtime);
 	}
 
-	nrm_fini(context);
-	nrm_ctxt_delete(context);
-
-    /* Delete scopes */
-    nrm_scope_delete(region_scope);
-    for (int i = 0; i < num_threads; i++)
-    {
-        nrm_scope_delete(thread_scope[i]);
-    }
-	
+	nrmb_finalize();
     /* compute stats */
 
 	/* report the configuration and timings */

--- a/src/utils.c
+++ b/src/utils.c
@@ -86,4 +86,5 @@ int nrmb_send_progress(double value)
 		global_count = 0.0;
 		last_progress = now;
 	}
+	return 0;
 }


### PR DESCRIPTION
Adapt all benchmarks to the current libnrm master, with progress reporting and aggregation on the bench side, without leveraging more complex APIs to batch events at this point.